### PR TITLE
fix(sync): restore AppOwner mnemonic non-null parity

### DIFF
--- a/packages/common/src/local-first/Owner.ts
+++ b/packages/common/src/local-first/Owner.ts
@@ -192,9 +192,7 @@ const createOwner = (secret: OwnerSecret): Owner => ({
  */
 export interface AppOwner extends Owner, Typed<"AppOwner"> {
   /**
-   * The mnemonic that was used to derive the AppOwner keys. Optional when the
-   * AppOwner is created from external keys to avoid sharing the mnemonic with
-   * the Evolu app.
+   * The mnemonic that was used to derive the AppOwner keys.
    *
    * TODO: Wrap with `Redacted` in the next major version.
    */

--- a/packages/common/test/local-first/Owner.test.ts
+++ b/packages/common/test/local-first/Owner.test.ts
@@ -38,6 +38,12 @@ test("createAppOwner is deterministic", () => {
   expect(owner1.mnemonic).toBeDefined();
 });
 
+test("createAppOwner mnemonic round-trips to the source secret", () => {
+  const appOwner = createAppOwner(testAppOwnerSecret);
+
+  expect(mnemonicToOwnerSecret(appOwner.mnemonic)).toEqual(testAppOwnerSecret);
+});
+
 test("deriveShardOwner is deterministic", () => {
   const appOwner = createAppOwner(testAppOwnerSecret);
 


### PR DESCRIPTION
## Summary
- restore upstream parity for AppOwner typing in packages/common/src/local-first/Owner.ts
- fix regression introduced after common-v8 merge where mnemonic became nullable
- align with upstream/common-v8 commit e6b0a6e intent (unnull mnemonic)

## Change
- `readonly mnemonic?: Mnemonic | null;` -> `readonly mnemonic: Mnemonic;`

## Verification
- bun clean
- bun install
- bun verify

All commands passed (only existing non-blocking Biome warnings in test files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Poznámky k vydání

* **Refaktorování**
  * Mnemonika u vlastníka aplikace je nyní povinná, což zlepšuje typovou bezpečnost a konzistenci inicializace objektů.
* **Testy**
  * Přidán test ověřující, že převod mnemoniky tam a zpět zachovává původní tajný klíč.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->